### PR TITLE
fix: Display character/weapon name on todo page instead of id

### DIFF
--- a/pages/todo.tsx
+++ b/pages/todo.tsx
@@ -64,7 +64,7 @@ const TodoPage = ({ planning, materialsMap }: TodoProps) => {
         }
 
         acc[key].push([
-          todo[0].id,
+          todo[0].name,
           todo[5][key] - todo[4][key],
           todo[5][key],
           i,


### PR DESCRIPTION
I hope this is okay, everything still seems to work on the to-do page locally

**Note:** my local version seems pretty broken after following the readme - lots of missing translation messages from `npm run dev` and the calculator API doesn't work, so I might have missed something that depends on this data being `id` vs `name`