### PR TITLE
fix: talent calculation offset by one level

### DIFF
--- a/pages/api/calculate_character_level.ts
+++ b/pages/api/calculate_character_level.ts
@@ -182,7 +182,7 @@ export default async function handler(
   // Calculate materials for talents
   const calculateTalentMaterials = (levelMin: number, levelMax: number) => {
     for (const talent of character.talent_materials) {
-      if (levelMin <= talent.level && talent.level <= levelMax) {
+      if (levelMin < talent.level && talent.level <= levelMax) {
         moraNeeded += talent.cost;
 
         for (let index = 0; index < talent.items.length; index++) {


### PR DESCRIPTION
fixes #19 

Since the talent materials for each level are stored in the level itself, using `<` instead of `<=` only sums up the materials after the current level. This skips the current level because the character is already on this level and does not need the materials for it.